### PR TITLE
Make "set" completion distinguish shell vs. windows-shell

### DIFF
--- a/src/main/kotlin/org/mvnsearch/plugins/just/lang/completion/JustSetCompletionContributor.kt
+++ b/src/main/kotlin/org/mvnsearch/plugins/just/lang/completion/JustSetCompletionContributor.kt
@@ -39,7 +39,7 @@ class JustSetCompletionContributor : CompletionContributor() {
                         result.addElement(LookupElementBuilder.create("tempdir := \"\""))
                         result.addElement(LookupElementBuilder.create("positional-arguments"))
                         result.addElement(LookupElementBuilder.create("shell := [\"bash\", \"-c\"]").withPresentableText("shell"))
-                        result.addElement(LookupElementBuilder.create("windows-shell := [\"pwsh.exe\", \"-NoLogo\",\"-Command\"]").withPresentableText("shell"))
+                        result.addElement(LookupElementBuilder.create("windows-shell := [\"pwsh.exe\", \"-NoLogo\",\"-Command\"]").withPresentableText("windows-shell"))
                         result.addElement(LookupElementBuilder.create("windows-powershell := true"))
                     }
                 }


### PR DESCRIPTION
Fixes
<img width="382" height="210" alt="image" src="https://github.com/user-attachments/assets/0a9c4e99-c829-420e-af7b-caadeaf48423" />
