### PR TITLE
Refactor Just file type configuration in plugin.xml

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,10 +8,11 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="justfile"
-                  implementationClass="org.mvnsearch.plugins.just.lang.psi.JustFileType"
-                  fieldName="INSTANCE" fileNamesCaseInsensitive="false"
-                  extensions="just"
-                  language="Just" fileNames="justfile;Justfile;.justfile,.Justfile"/>
+            implementationClass="org.mvnsearch.plugins.just.lang.psi.JustFileType"
+            fieldName="INSTANCE"
+            extensions="just;Justfile;justfile"
+            language="Just"
+            fileNames="justfile" />
         <codeInsight.lineMarkerProvider language="Just"
                                         implementationClass="org.mvnsearch.plugins.just.lang.run.JustRunLineMarkerContributor"/>
         <codeInsight.lineMarkerProvider language="Just"


### PR DESCRIPTION
This will associate the plugnin with the following patterns:

- *.just
- *.justfile
- *.Justfile
- Justfile
- justfile

## Current status (with defaults from the plugin)
<img width="198" height="190" alt="image" src="https://github.com/user-attachments/assets/d411eb26-8f79-4d84-ab30-c436a480f0ac" />

Please note the following:
- the `false` pattern :shrug: 
- the invalid `.justfile,.Justfile` (this is coming from the `,` used as a separator, while `;` should be used)

## Notes:
I based those changes according to https://plugins.jetbrains.com/docs/intellij/registering-file-type.html#registration and https://plugins.jetbrains.com/docs/intellij/language-and-filetype.html#register-the-file-type

## Thanks
Thank you for the plugin and for your work maintaining it!

