### PR TITLE
Making shell code checks more robust for syntax highlighting

### DIFF
--- a/src/main/kotlin/org/mvnsearch/plugins/just/lang/injector/JustCodeBlockLanguageInjector.kt
+++ b/src/main/kotlin/org/mvnsearch/plugins/just/lang/injector/JustCodeBlockLanguageInjector.kt
@@ -33,7 +33,7 @@ class JustCodeBlockLanguageInjector : MultiHostInjector {
         val justFile = context.containingFile as JustFile
         val text = context.text
         val trimmedText = text.trim()
-        if (shellLanguage != null && justFile.isBashAlike() && isShellCode(trimmedText)) {
+        if (shellLanguage != null && justFile.isBashAlike() && isShellCode(trimmedText, justFile.hasShellConfig())) {
             var injectionScript = justFile.getExportedVariables().joinToString(separator = "") { "$it=''\n" }
             val recipeStatement = context.parentOfType<JustRecipeStatement>()
             if (recipeStatement != null) {
@@ -106,21 +106,28 @@ class JustCodeBlockLanguageInjector : MultiHostInjector {
         return mutableListOf(JustCodeBlock::class.java)
     }
 
-    private fun isShellCode(trimmedCode: String): Boolean {
+    private fun isShellCode(trimmedCode: String, fileDeclaresShell: Boolean): Boolean {
         val firstWord = trimmedCode.substringBefore(' ').lowercase()
-        if (firstWord in arrayOf("select", "update", "delete", "insert")) { //SQL style
+        if (firstWord in arrayOf("select", "update", "delete", "insert")) {
             return false
+        }
+        if (trimmedCode.startsWith("#!/usr/bin/env sh")
+            || trimmedCode.startsWith("#!/usr/bin/env bash")
+            || trimmedCode.startsWith("#!/usr/bin/env zsh")
+            || trimmedCode.startsWith("#!/usr/bin/env fish")) {
+            return true
+        }
+        if (trimmedCode.startsWith("#!")) {
+            return false
+        }
+        if (fileDeclaresShell) {
+            return true
         }
         if (trimmedCode.contains("{{") || trimmedCode.contains("}}")) {
             // enable highlight for parameter in string
             return (trimmedCode.contains("\"{{") || trimmedCode.contains("'{{")) && !trimmedCode.contains(" {{")
         }
-        // check shell shebang
-        return !trimmedCode.startsWith("#!")
-                || trimmedCode.startsWith("#!/usr/bin/env sh")
-                || trimmedCode.startsWith("#!/usr/bin/env bash")
-                || trimmedCode.startsWith("#!/usr/bin/env zsh")
-                || trimmedCode.startsWith("#!/usr/bin/env fish")
+        return true
     }
 
     private fun isSQLCode(trimmedCode: String): Boolean {

--- a/src/main/kotlin/org/mvnsearch/plugins/just/lang/psi/JustFile.kt
+++ b/src/main/kotlin/org/mvnsearch/plugins/just/lang/psi/JustFile.kt
@@ -50,13 +50,20 @@ class JustFile(viewProvider: FileViewProvider?) : PsiFileBase(viewProvider!!, Ju
     fun isBashAlike(): Boolean {
         val shellItem = this.children
             .filterIsInstance<JustSetStatement>().firstOrNull() {
-                it.setting.text == "shell" || it.setting.text == "windows-shell"
+                it.setting.text == "shell" || it.setting.text == "windows-shell" || it.setting.text == "script-interpreter"
             }
         return if (shellItem == null) {
             true
         } else {
             shellItem.text.contains("sh\"")
         }
+    }
+
+    fun hasShellConfig(): Boolean {
+        return this.children
+            .filterIsInstance<JustSetStatement>().any {
+                it.setting.text == "shell" || it.setting.text == "windows-shell" || it.setting.text == "script-interpreter"
+            }
     }
 
     fun isSQLAlike(): Boolean {


### PR DESCRIPTION
The checks for whether a recipe is shell code needed some improvement.

Before:
<img width="772" height="666" alt="image" src="https://github.com/user-attachments/assets/eb6abf58-b454-4653-ba42-ffc84a60eeab" />

This change accounts for more cases and checks the `set` statements

After:
<img width="804" height="747" alt="image" src="https://github.com/user-attachments/assets/97319831-616d-48d3-b8dc-c9683fb686e5" />
